### PR TITLE
Factor in nbt when transfering items

### DIFF
--- a/src/main/java/yalter/mousetweaks/DeobfuscationLayer.java
+++ b/src/main/java/yalter/mousetweaks/DeobfuscationLayer.java
@@ -132,7 +132,8 @@ public class DeobfuscationLayer {
     }
 
     protected static boolean areStacksCompatible(ItemStack itemStack1, ItemStack itemStack2) {
-        return ((itemStack1 == null) || (itemStack2 == null)) || itemStack1.isItemEqual(itemStack2);
+        return ((itemStack1 == null) || (itemStack2 == null))
+                || (itemStack1.isItemEqual(itemStack2) && ItemStack.areItemStackTagsEqual(itemStack1, itemStack2));
     }
 
     protected static Slot getSelectedSlot(GuiContainer guiContainer, Container container, int slotCount) {


### PR DESCRIPTION
Fixes an issue where items that have the same metadata but differing nbt (like fluid cells) will be swapped when you use the scroll wheel to transfer between inventories brought up in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/15418#issuecomment-1912167676