### PR TITLE
Force disable mouse wheel transfer if NEI's mouse wheel transfer is active

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,3 +1,4 @@
 dependencies {
-    api("com.github.GTNewHorizons:GTNHLib:0.2.9:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.5.20:dev")
+    implementation('com.github.GTNewHorizons:NotEnoughItems:2.6.45-GTNH:dev')
 }

--- a/src/main/java/yalter/mousetweaks/DeobfuscationLayer.java
+++ b/src/main/java/yalter/mousetweaks/DeobfuscationLayer.java
@@ -30,7 +30,7 @@ public class DeobfuscationLayer {
     }
 
     protected static boolean isGuiContainer(GuiScreen guiScreen) {
-        return (guiScreen != null) && (guiScreen instanceof GuiContainer);
+        return guiScreen instanceof GuiContainer;
     }
 
     protected static boolean isValidGuiContainer(GuiScreen guiScreen) {


### PR DESCRIPTION
Both MouseTweaks and NEI implement a feature that allows to transfer items in GuiContainers by using the mouse wheel.

Recently the default configs got changed to have NEI one enabled by default and not mouse tweak's. When both are enabled it leads to items transfering twice. 

To avoid unnecessary bug reports and tickets from players that might have both active in their configs, I am disabling this one when NEI one is active.